### PR TITLE
Do not wrap parameters

### DIFF
--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
+  wrap_parameters format: [] if respond_to?(:wrap_parameters)
 end
 
 # To enable root element in JSON for ActiveRecord objects.


### PR DESCRIPTION
It does not work for ALL controllers automatically because
they accept params which are not imatch attributes of the related model.

Fixes #28