### PR TITLE
Feature/segments options

### DIFF
--- a/app/controllers/api/presets_controller.rb
+++ b/app/controllers/api/presets_controller.rb
@@ -15,6 +15,7 @@ module Api
     #       "name":"h264",
     #       "parameters":"-acodec libfaac -ab 96k -ar 44100 -vcodec libx264 -vb 416k -vpre slow -vpre baseline -s 320x180 -y",
     #       "thumbnail_options":null,
+    #       "segments_options":null,
     #       "updated_at":"2011-05-09T11:59:53Z"}
     #     }
     #   ]
@@ -33,6 +34,7 @@ module Api
     # <tt>params</tt>:: Parameters to use
     # Optional:
     # <tt>thumbnail_options</tt>:: Thumbnail options to use
+    # <tt>segments_options</tt>:: Thumbnail options to use
     #
     # === Response codes
     # <tt>success</tt>:: <tt>201 created</tt>
@@ -47,6 +49,7 @@ module Api
     #     "name":"webm",
     #     "parameters":"params",
     #     "thumbnail_options":null,
+    #     "segments_options":null,
     #     "updated_at":"2011-05-10T14:44:07Z"}
     #   }
     def create
@@ -103,11 +106,12 @@ module Api
         params[:name] = params[:preset][:name]
         params[:parameters] = params[:preset][:parameters]
         params[:thumbnail_options] = params[:preset][:thumbnail_options]
+        params[:segments_options] = params[:preset][:segments_options]
       end
 
       preset = Preset.find(params[:id])
 
-      if preset.update_attributes(name: params[:name], parameters: params[:parameters], thumbnail_options: params[:thumbnail_options])
+      if preset.update_attributes(name: params[:name], parameters: params[:parameters], thumbnail_options: params[:thumbnail_options], segments_options: params[:segments_options])
         respond_with preset, location: api_preset_url(preset) do |format|
           format.html { redirect_to presets_path }
         end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -16,6 +16,8 @@ class Job < ActiveRecord::Base
   before_destroy :remove_job_from_transcoder
 
   serialize :arguments
+  serialize :thumbnails
+  serialize :segments
 
   scope :scheduled,   -> { where(state: Scheduled) }
   scope :processing,  -> { where(state: Processing) }

--- a/app/models/jobs/states.rb
+++ b/app/models/jobs/states.rb
@@ -61,8 +61,11 @@ module Jobs
     def enter_success(params)
       update_attributes(
         completed_at: Time.current,
-        message: params['message'],
-        progress: 1.0
+        message:      params['message'],
+        thumbnails:   params['thumbnails'],
+        playlist:     params['playlist'],
+        segments:     params['segments'],
+        progress:     1.0
       )
       notify
     end

--- a/app/models/preset.rb
+++ b/app/models/preset.rb
@@ -2,29 +2,29 @@ class Preset < ActiveRecord::Base
   has_many :jobs
 
   validates :name, presence: true, uniqueness: true
+  validates :thumbnail_options, :segments_options, json: true, allow_blank: true
 
   validate :should_have_params_or_thumbnail_options
-  validate :thumbnail_options, :valid_json_options, if: proc { |p| p.thumbnail_options.present? }
+  validate :should_have_params_for_segments_options
 
   def self.from_api(attributes)
     attributes = attributes[:preset] if attributes[:preset]
     create(name: attributes['name'],
            parameters: attributes['parameters'],
-           thumbnail_options: attributes['thumbnail_options'])
+           thumbnail_options: attributes['thumbnail_options'],
+           segments_options: attributes['segments_options'])
   end
 
   private
 
-  def valid_json_options
-    JSON.parse(thumbnail_options)
-    true
-  rescue JSON::ParserError
-    errors.add(:thumbnail_options, 'must be valid JSON')
-    false
-  end
-
   def should_have_params_or_thumbnail_options
     return true if parameters.present? || thumbnail_options.present?
     errors.add(:base, 'Either parameters or thumbnail options should be specified')
+  end
+
+  def should_have_params_for_segments_options
+    if parameters.blank? && segments_options.present?
+      errors.add(:base, 'Encoding parameters required for segmenting video')
+    end
   end
 end

--- a/app/models/transcoder.rb
+++ b/app/models/transcoder.rb
@@ -13,17 +13,23 @@ class Transcoder
     end
 
     def job_to_json(job)
+      thumb_opts = nil
+      segments_options = nil
+
       if job.preset.thumbnail_options.present?
         thumb_opts = JSON.parse(job.preset.thumbnail_options)
-      else
-        thumb_opts = nil
+      end
+
+      if job.preset.segments_options.present?
+        segments_options = JSON.parse(job.preset.segments_options)
       end
 
       {
         'source_file' => job.source_file,
         'destination_file' => job.destination_file,
         'encoder_options' => job.preset.parameters,
-        'thumbnail_options' => thumb_opts
+        'thumbnail_options' => thumb_opts,
+        'segments_options' => segments_options
       }.to_json
     end
 

--- a/app/validators/json_validator.rb
+++ b/app/validators/json_validator.rb
@@ -1,0 +1,7 @@
+class JsonValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    JSON.parse(value)
+  rescue JSON::ParserError
+    record.errors[attribute] << (options[:message] || 'must be valid JSON')
+  end
+end

--- a/app/views/presets/_form.html.erb
+++ b/app/views/presets/_form.html.erb
@@ -31,10 +31,18 @@
     </div>
 
     <div class="control-group">
-      <%= f.label :thumbnail_options, class: 'control-label required' %>
+      <%= f.label :thumbnail_options, class: 'control-label' %>
       <div class="controls">
         <%= f.text_field :thumbnail_options, class: 'form-control' %>
       <a href="#thumbnail_help" role="button" class="btn" data-toggle="modal">Help</a>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <%= f.label :segments_options, class: 'control-label' %>
+      <div class="controls">
+        <%= f.text_field :segments_options, class: 'form-control' %>
+      <a href="#segments_help" role="button" class="btn" data-toggle="modal">Help</a>
       </div>
     </div>
 
@@ -70,6 +78,35 @@
             <li>A size can be specified in pixels (width x height). If omitted it will generate thumbnails the size of the source video. (optional)</li>
             <li>A format for the thumbnails. The format must be supported by your ffmpeg binary. If omitted it will generate thumbnails in the JPEG format. Most people will use either "jpg" or "png". (optional)</li>
           </ul>		
+        </ul>
+      </ul>
+      <p>See <a href="https://github.com/madebyhiro/codem-transcode#usage">github.com/madebyhiro/codem-transcode#usage</a> for more info.</p>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">Close</button>
+    </div>
+  </div>
+</div>
+</div>
+
+<div class="modal fade" id="segments_help">
+  <div class="modal-dialog">
+    <div class="modal-content">
+
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h3>Segments options</h3>
+      </div>
+      <div class="modal-body">
+        <p>
+          It's possible to generate segments while transcoding the input file.
+          These options can be specified for each preset, and use the following syntax:
+        </p>
+        <ul>
+          <li>Valid options are:</li>
+          <ul>
+   	    <li><p>A segment_time: <pre>{ "segment_time": 10 }</pre> will generate segments at every 10 secconds.</p></li>
+          </ul>
         </ul>
       </ul>
       <p>See <a href="https://github.com/madebyhiro/codem-transcode#usage">github.com/madebyhiro/codem-transcode#usage</a> for more info.</p>

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
+  wrap_parameters format: [] if respond_to?(:wrap_parameters)
 end
 
 # To enable root element in JSON for ActiveRecord objects.

--- a/db/migrate/20140822123729_add_segments_options_to_presets.rb
+++ b/db/migrate/20140822123729_add_segments_options_to_presets.rb
@@ -1,0 +1,5 @@
+class AddSegmentsOptionsToPresets < ActiveRecord::Migration
+  def change
+    add_column :presets, :segments_options, :text
+  end
+end

--- a/db/migrate/20140822153009_add_thumbnails_to_jobs.rb
+++ b/db/migrate/20140822153009_add_thumbnails_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddThumbnailsToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :thumbnails, :text
+  end
+end

--- a/db/migrate/20140822153109_add_segments_to_jobs.rb
+++ b/db/migrate/20140822153109_add_segments_to_jobs.rb
@@ -1,0 +1,6 @@
+class AddSegmentsToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :playlist, :string
+    add_column :jobs, :segments, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,95 +9,99 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140522082136) do
+ActiveRecord::Schema.define(version: 20140822153109) do
 
-  create_table 'deliveries', :force => true do |t|
-    t.integer  'notification_id', :null => false
-    t.string   'state',           :null => false
-    t.datetime 'notified_at',     :null => false
-    t.datetime 'created_at',      :null => false
-    t.datetime 'updated_at',      :null => false
-    t.integer  'state_change_id'
+  create_table "deliveries", force: true do |t|
+    t.integer  "notification_id", null: false
+    t.string   "state",           null: false
+    t.datetime "notified_at",     null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.integer  "state_change_id"
   end
 
-  add_index 'deliveries', ['notification_id'], :name => 'index_deliveries_on_notification_id'
-  add_index 'deliveries', ['state_change_id'], :name => 'index_deliveries_on_state_change_id'
+  add_index "deliveries", ["notification_id"], name: "index_deliveries_on_notification_id", using: :btree
+  add_index "deliveries", ["state_change_id"], name: "index_deliveries_on_state_change_id", using: :btree
 
-  create_table 'hosts', :force => true do |t|
-    t.string   'name',                                 :null => false
-    t.string   'url',                                  :null => false
-    t.datetime 'created_at',                           :null => false
-    t.datetime 'updated_at',                           :null => false
-    t.boolean  'available',         :default => false
-    t.integer  'total_slots',       :default => 0
-    t.integer  'available_slots',   :default => 0
-    t.datetime 'status_updated_at'
+  create_table "hosts", force: true do |t|
+    t.string   "name",                              null: false
+    t.string   "url",                               null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.boolean  "available",         default: false
+    t.integer  "total_slots",       default: 0
+    t.integer  "available_slots",   default: 0
+    t.datetime "status_updated_at"
   end
 
-  add_index 'hosts', ['name'], :name => 'index_hosts_on_name'
+  add_index "hosts", ["name"], name: "index_hosts_on_name", using: :btree
 
-  create_table 'jobs', :force => true do |t|
-    t.string   'source_file',                                                   :null => false
-    t.string   'destination_file',                                              :null => false
-    t.integer  'preset_id',                                                     :null => false
-    t.datetime 'created_at',                                                    :null => false
-    t.datetime 'updated_at',                                                    :null => false
-    t.string   'state'
-    t.string   'remote_job_id'
-    t.datetime 'transcoding_started_at'
-    t.integer  'host_id'
-    t.text     'message',                :limit => 16777215
-    t.float    'progress'
-    t.integer  'duration'
-    t.string   'filesize'
-    t.datetime 'completed_at'
-    t.text     'arguments'
-    t.boolean  'locked',                                     :default => false
-    t.integer  'priority',               :limit => 3
+  create_table "jobs", force: true do |t|
+    t.string   "source_file",                                             null: false
+    t.string   "destination_file",                                        null: false
+    t.integer  "preset_id",                                               null: false
+    t.datetime "created_at",                                              null: false
+    t.datetime "updated_at",                                              null: false
+    t.string   "state"
+    t.string   "remote_job_id"
+    t.datetime "transcoding_started_at"
+    t.integer  "host_id"
+    t.text     "message",                limit: 16777215
+    t.float    "progress"
+    t.integer  "duration"
+    t.string   "filesize"
+    t.datetime "completed_at"
+    t.text     "arguments"
+    t.boolean  "locked",                                  default: false
+    t.integer  "priority",               limit: 3
+    t.text     "thumbnails"
+    t.string   "playlist"
+    t.text     "segments"
   end
 
-  add_index 'jobs', ['completed_at'], :name => 'index_jobs_on_completed_at'
-  add_index 'jobs', ['created_at'], :name => 'index_jobs_on_created_at'
-  add_index 'jobs', ['source_file'], :name => 'index_jobs_on_source_file'
-  add_index 'jobs', ['state'], :name => 'index_jobs_on_state'
-  add_index 'jobs', ['transcoding_started_at'], :name => 'index_jobs_on_transcoding_started_at'
+  add_index "jobs", ["completed_at"], name: "index_jobs_on_completed_at", using: :btree
+  add_index "jobs", ["created_at"], name: "index_jobs_on_created_at", using: :btree
+  add_index "jobs", ["source_file"], name: "index_jobs_on_source_file", using: :btree
+  add_index "jobs", ["state"], name: "index_jobs_on_state", using: :btree
+  add_index "jobs", ["transcoding_started_at"], name: "index_jobs_on_transcoding_started_at", using: :btree
 
-  create_table 'notifications', :force => true do |t|
-    t.integer  'job_id'
-    t.string   'type'
-    t.string   'value'
-    t.datetime 'created_at',  :null => false
-    t.datetime 'updated_at',  :null => false
-    t.string   'state'
-    t.datetime 'notified_at'
+  create_table "notifications", force: true do |t|
+    t.integer  "job_id"
+    t.string   "type"
+    t.string   "value"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.string   "state"
+    t.datetime "notified_at"
   end
 
-  add_index 'notifications', ['job_id'], :name => 'index_notifications_on_job_id'
+  add_index "notifications", ["job_id"], name: "index_notifications_on_job_id", using: :btree
 
-  create_table 'presets', :force => true do |t|
-    t.string   'name',              :null => false
-    t.datetime 'created_at',        :null => false
-    t.datetime 'updated_at',        :null => false
-    t.text     'parameters'
-    t.text     'thumbnail_options'
+  create_table "presets", force: true do |t|
+    t.string   "name",              null: false
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.text     "parameters"
+    t.text     "thumbnail_options"
+    t.text     "segments_options"
   end
 
-  add_index 'presets', ['name'], :name => 'index_presets_on_name'
+  add_index "presets", ["name"], name: "index_presets_on_name", using: :btree
 
-  create_table 'state_changes', :force => true do |t|
-    t.integer  'job_id'
-    t.string   'state'
-    t.text     'message',     :limit => 16777215
-    t.datetime 'created_at',                      :null => false
-    t.datetime 'updated_at',                      :null => false
-    t.float    'notified_at'
-    t.integer  'position'
+  create_table "state_changes", force: true do |t|
+    t.integer  "job_id"
+    t.string   "state"
+    t.text     "message",     limit: 16777215
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.float    "notified_at"
+    t.integer  "position"
   end
 
-  add_index 'state_changes', ['job_id'], :name => 'index_state_changes_on_job_id'
-  add_index 'state_changes', ['notified_at'], :name => 'index_state_changes_on_notified_at'
-  add_index 'state_changes', ['position'], :name => 'index_state_changes_on_position'
+  add_index "state_changes", ["job_id"], name: "index_state_changes_on_job_id", using: :btree
+  add_index "state_changes", ["notified_at"], name: "index_state_changes_on_notified_at", using: :btree
+  add_index "state_changes", ["position"], name: "index_state_changes_on_position", using: :btree
 
 end

--- a/spec/features/presets/creating_spec.rb
+++ b/spec/features/presets/creating_spec.rb
@@ -11,6 +11,7 @@ feature 'Creating a preset' do
     fill_in 'Name', with: 'name'
     fill_in 'Parameters', with: 'foo'
     fill_in 'Thumbnail options', with: '{"foo":"bar"}'
+    fill_in 'Segments options', with: '{"seg":"ment"}'
   end
 
   scenario 'should work' do
@@ -20,6 +21,7 @@ feature 'Creating a preset' do
     expect(p.name).to eq('name')
     expect(p.parameters).to eq('foo')
     expect(p.thumbnail_options).to eq('{"foo":"bar"}')
+    expect(p.segments_options).to eq('{"seg":"ment"}')
   end
 
   scenario 'no name' do
@@ -39,5 +41,18 @@ feature 'Creating a preset' do
     fill_in 'Thumbnail options', with: 'foo:bar'
     click_button 'Create Preset'
     expect(page).to have_text('Thumbnail options must be valid JSON')
+  end
+
+  scenario 'invalid segments options' do
+    fill_in 'Segments options', with: 'foo:bar'
+    click_button 'Create Preset'
+    expect(page).to have_text('Segments options must be valid JSON')
+  end
+
+  scenario 'segments options without encoding parameters' do
+    fill_in 'Parameters', with: ''
+    fill_in 'Segments options', with: '{"seg":"ment"}'
+    click_button 'Create Preset'
+    expect(page).to have_text('Encoding parameters required for segmenting video')
   end
 end

--- a/spec/features/presets/editing_spec.rb
+++ b/spec/features/presets/editing_spec.rb
@@ -18,4 +18,13 @@ feature 'Editing a preset' do
     click_button 'Update Preset'
     expect(page).to have_text('new params')
   end
+
+  scenario 'editing segments options' do
+    visit presets_path
+    click_link 'Edit'
+    fill_in 'Segments options', with: '{"SEG": "MENT"}'
+    click_button 'Update Preset'
+    click_link 'Edit'
+    expect(page).to have_selector(%q{input[value='{"SEG": "MENT"}']})
+  end
 end

--- a/spec/models/jobs/states_spec.rb
+++ b/spec/models/jobs/states_spec.rb
@@ -129,12 +129,19 @@ describe Jobs::States, type: :model do
     end
 
     def do_enter
-      job.enter(Job::Success,  'message' => 'msg')
+      job.enter(Job::Success, 'message'    => 'msg',
+                              'thumbnails' => ['thumb.jpg'],
+                              'playlist'   => 'playlist.m3u8',
+                              'segments'   => ['segment.ts'])
+      job.reload
     end
 
     it 'should set the parameters' do
       do_enter
       expect(job.message).to eq('msg')
+      expect(job.thumbnails).to eq(['thumb.jpg'])
+      expect(job.playlist).to eq('playlist.m3u8')
+      expect(job.segments).to eq(['segment.ts'])
       expect(job.completed_at).to eq(@t)
       expect(job.progress).to eq(1.0)
     end

--- a/spec/models/preset_spec.rb
+++ b/spec/models/preset_spec.rb
@@ -3,11 +3,14 @@ require 'spec_helper'
 describe Preset, type: :model do
   describe 'generating a preset via the API' do
     it 'should map the attributes correctly' do
-      Preset.from_api('name' => 'name', 'parameters' => 'params', 'thumbnail_options' => '{"seconds":1}')
+      Preset.from_api('name' => 'name', 'parameters' => 'params',
+                      'thumbnail_options' => '{"seconds":1}',
+                      'segments_options' => '{"segment_time":10}')
       p = Preset.last
       expect(p.name).to eq('name')
       expect(p.parameters).to eq('params')
       expect(p.thumbnail_options).to eq('{"seconds":1}')
+      expect(p.segments_options).to eq('{"segment_time":10}')
     end
   end
 
@@ -39,6 +42,24 @@ describe Preset, type: :model do
       p.thumbnail_options = 'foo'
       expect(p).not_to be_valid
       expect(p.errors[:thumbnail_options]).to eq(['must be valid JSON'])
+    end
+
+    it 'should not be valid with segments options and thumb options and no params' do
+      p = Preset.new
+      p.name = 'foo'
+      p.parameters = ''
+      p.thumbnail_options = '{"seconds":1}'
+      p.segments_options = '{"segment_time":10}'
+      expect(p).not_to be_valid
+    end
+
+    it 'should not be valid with non-JSON segments options' do
+      p = Preset.new
+      p.name = 'foo'
+      p.parameters = 'params'
+      p.thumbnail_options = '{"seconds":1}'
+      p.segments_options = 'foo'
+      expect(p).not_to be_valid
     end
   end
 end

--- a/spec/models/transcoder_spec.rb
+++ b/spec/models/transcoder_spec.rb
@@ -36,12 +36,13 @@ describe Transcoder, type: :model do
     end
 
     it 'should convert a job to transcoder params correctly' do
-      # with thumbnail options presetn
+      # with thumbnail options present
       expect(Transcoder.job_to_json(@job)).to eq({
         'source_file' => 'source',
         'destination_file' => 'dest',
         'encoder_options' => 'params',
-        'thumbnail_options' => { seconds: 1 }
+        'thumbnail_options' => { seconds: 1 },
+        'segments_options' => nil
       }.to_json)
 
       # without thumbnail options
@@ -50,7 +51,18 @@ describe Transcoder, type: :model do
         'source_file' => 'source',
         'destination_file' => 'dest',
         'encoder_options' => 'params',
-        'thumbnail_options' => nil
+        'thumbnail_options' => nil,
+        'segments_options' => nil
+      }.to_json)
+
+      # with segments options
+      @job.preset.segments_options = '{"segment_time": 10}'
+      expect(Transcoder.job_to_json(@job)).to eq({
+        'source_file' => 'source',
+        'destination_file' => 'dest',
+        'encoder_options' => 'params',
+        'thumbnail_options' => nil,
+        'segments_options' => { segment_time: 10 },
       }.to_json)
     end
   end


### PR DESCRIPTION
`segments_options` support for codem-transcode.
Support of these options is added by
https://github.com/madebyhiro/codem-transcode/pull/33/files

`segments_options` stores valid JSON string just like `thumbnail_options`.
So far the only valid option is `segment_time`.

```ruby
{ "segment_time": 10 }
```

Also /api/jobs/:id.json now shows thumbnails, playlist and segments returned from
the transcoder.

This code also includes "wrap_parameters" fix. #29