### PR TITLE
Update schedule.rb

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -19,7 +19,8 @@ class Schedule
     end
 
     def to_be_updated_jobs
-      Job.where(state: [Job::Scheduled, Job::Processing, Job::OnHold]).order('created_at')
+        limit = Host.all.length;
+        Job.where(state: [Job::Processing, Job::OnHold, Job::Scheduled]).order('state desc').limit(limit);
     end
 
     def available_slots


### PR DESCRIPTION
Hey, i'm using this great tool with a lot of scheduled jobs in a sqlite3 database; So i ran into trouble because everytime api/schedule is called, the app was blocked, because of the locked database while updating ALL jobs.
So, i decided to limit the number of updated jobs and change the order by state, too. 
Maybe its more intelligent to change the limit of updated jobs to the number of hosts/slots available.